### PR TITLE
[_]: fix/use-user-uuid-to-join-a-room

### DIFF
--- a/src/auth-socket-middleware.ts
+++ b/src/auth-socket-middleware.ts
@@ -17,11 +17,17 @@ export default function registerAuthSocketMiddleware(io: Server) {
         logger.warn(`Failed to verify a token, error: ${JSON.stringify(err, null, 2)}`);
         next(new Error());
       }
-      logger.info(`Token decoded: ${decoded}`);
+      logger.info(`Token decoded: ${JSON.stringify(decoded, null, 2)}`);
 
-      if (decoded && typeof decoded !== 'string' && decoded.userId) {
-        logger.info(`userId: ${decoded.userId} is listening notifications`);
-        socket.join(decoded.userId);
+      if (
+        decoded && 
+        typeof decoded !== 'string' && 
+        decoded.payload && 
+        decoded.payload.uuid
+      ) {
+        const uuid = decoded.payload.uuid;
+        logger.info(`user: ${uuid} is listening notifications`);
+        socket.join(uuid);
       } else {
         const email = typeof decoded === 'string' ? decoded : decoded!.email;
         logger.info(`email: ${email} is listening notifications`);


### PR DESCRIPTION
Use the user UUID from the JWT token to join a room:

When the new token is used - **at the date of the PR**, this new token has the data of the user in the payload, including the UUID -. Use it to join a room, therefore any device from that client could join the same room, being able to listen to any event related to that user. 