### PR TITLE
chore: add splat to logs

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -12,6 +12,7 @@ const winstonProdOptions: winston.LoggerOptions = {
   handleExceptions: true,
   format: combine(
     timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
+    splat(),
     printf((info) => {
       return JSON.stringify({
         hostname: serverHostname,


### PR DESCRIPTION
Errors were not showing correctly due to missing winston config.

splat() enables string interpolation